### PR TITLE
feat: Configure GitHub Pages for app demo

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  # Or your default branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Set base href
+        run: |
+          REPO_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f2)
+          BASE_HREF="/$REPO_NAME/"
+          # If deploying to username.github.io (root for the user/org), BASE_HREF should be "/"
+          # This simple check assumes the repo name is not the same as the username/org name,
+          # which is a common case for project pages.
+          # A more robust solution might be needed for user/org pages deployed from a repo with the same name.
+          if [ "$REPO_NAME" = "$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f1).github.io" ]; then
+            BASE_HREF="/"
+          fi
+          sed -i "s|<base href_placeholder />|<base href=\"$BASE_HREF\" />|" "ifaketextmessage APP/index.html"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: 'ifaketextmessage APP' # Specify the directory to deploy
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/ifaketextmessage APP/index.html
+++ b/ifaketextmessage APP/index.html
@@ -27,11 +27,12 @@
 	<meta name="description" content="Fake Text Message is a tool to create a Fake Text Conversation and a Fake iMessage." />
 	<meta name="author" content="Dillon Hess" />
 	<meta name="Copyright" content="Copyright iFakeTextMessage 2021. All Rights Reserved." />
+	<base href_placeholder />
 	
 	<meta property="og:title" content="Fake Text Message | Make Fake Text Conversation" />
 	<meta property="og:type" content="website" />
-	<meta property="og:url" content="/" />
-	<meta property="og:image" content="/theme/images/fake_text_message_og.jpg" />
+	<meta property="og:url" content="./" />
+	<meta property="og:image" content="theme/images/fake_text_message_og.jpg" />
 	<meta property="og:description" content="Fake Text Message is a tool to create a Fake Text Conversation and a Fake iMessage." />
 	
 </head>
@@ -43,7 +44,7 @@
 		<div class="paramsWrapper">
 		
 			<div class="titleSection">
-	<a href="robots.txt" class="title">
+	<a href="./" class="title">
 		<img src="theme/images/ifake_text_message_iphone_logo.png" title="iFake Text Message | Create Fake Text Message Conversation" />
 		<h1>iFake Text Message</h1>
 	</a>
@@ -51,8 +52,8 @@
 	<div class="mobile-menu">
 		<div class="mobile-menu-icon"><div class="mobile-menu-icon-line"></div><div class="mobile-menu-icon-line"></div><div class="mobile-menu-icon-line"></div></div>
 		<div class="mobile-menu-links">
-			<div class="mobile-menu-link" href="/"><a href="robots.txt"><img src="theme/images/ifake_text_message_iphone_logo.png" title="iFake Text Message | Create Fake Text Message Conversation" /></a></div>
-			<a class="mobile-menu-link" href="robots.txt">Create</a>
+			<div class="mobile-menu-link" href="./"><a href="./"><img src="theme/images/ifake_text_message_iphone_logo.png" title="iFake Text Message | Create Fake Text Message Conversation" /></a></div>
+			<a class="mobile-menu-link" href="./">Create</a>
 			<a class="mobile-menu-link" href="tutorial/index.html">Tutorial</a>
 			<a class="mobile-menu-link" href="about/index.html">About</a>
 			<a class="mobile-menu-link" href="faq/index.html">FAQ</a>
@@ -61,7 +62,7 @@
 	<div class="mobile-menu-bg"></div>
 </div>
 			
-			<form method="post" action="/process.php" enctype="multipart/form-data" class="text-message-form">
+			<form method="post" action="process.php" enctype="multipart/form-data" class="text-message-form">
 			<div class="params">
 				
 				<div class="section section-message">


### PR DESCRIPTION
- Add GitHub Actions workflow to build and deploy the app from the 'ifaketextmessage APP' directory to GitHub Pages.
- Update 'ifaketextmessage APP/index.html':
    - Add a <base href="..."> tag, which will be dynamically set by the workflow to ensure correct asset pathing on GitHub Pages.
    - Update internal links and asset paths to be relative to the base URL.
- You need to enable GitHub Pages in repository settings (Source: GitHub Actions) and push these changes to trigger the first deployment.