### PR TITLE
docs: Add GitHub Pages demo instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # Fakechatapp
+
+## Online Demo
+
+This application can be viewed online as a live demo deployed via GitHub Pages.
+
+**Demo URL:** [Link to Demo Page - Will be available after first deployment] *(Replace this with the actual URL once deployed)*
+
+### Instructions for Repository Owner to Deploy and View Demo:
+
+1.  **Ensure Previous Setup is Complete:**
+    *   The GitHub Actions workflow file (`.github/workflows/deploy-gh-pages.yml`) should exist.
+    *   `ifaketextmessage APP/index.html` should be updated with a `<base href="...">` tag for GitHub Pages compatibility. (These changes were part of the previous "feat: Configure GitHub Pages for app demo" commit).
+
+2.  **Commit and Push Changes:**
+    *   If you haven't already, commit and push all changes (including the workflow file and `index.html` modifications) to your main branch on GitHub.
+
+3.  **Enable GitHub Pages:**
+    *   Go to your repository on GitHub.
+    *   Click on the "Settings" tab.
+    *   In the left sidebar, navigate to the "Pages" section.
+    *   Under "Build and deployment", for the "Source" option, select "GitHub Actions".
+
+4.  **Monitor Deployment:**
+    *   Go to the "Actions" tab in your repository.
+    *   A workflow named "Deploy to GitHub Pages" should start automatically after you push to main and configure Pages.
+    *   Wait for the workflow to complete successfully.
+
+5.  **Access Demo and Update README:**
+    *   Once deployed, the live demo will be available at a URL similar to: `https://<your-username>.github.io/<repository-name>/`
+    *   You can find the exact URL in your repository's "Settings" > "Pages" section.
+    *   **Important:** Edit this `README.md` file and replace the placeholder "[Link to Demo Page - Will be available after first deployment]" with the actual live URL.


### PR DESCRIPTION
- I'll add an "Online Demo" section to README.md.
- I'll include a placeholder for the demo URL.
- I'll provide detailed instructions for you on how to deploy the app to GitHub Pages and update the README with the live URL.