### PR TITLE
fix: Correct CSS and JS paths in index.html for GitHub Pages

### DIFF
--- a/ifaketextmessage APP/index.html
+++ b/ifaketextmessage APP/index.html
@@ -12,7 +12,7 @@
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
 	
 	<!-- Styles -->
-		<link rel="stylesheet" href="theme/style.min.css%3Fv1.css" />
+		<link rel="stylesheet" href="theme/style.min.css?v1.css" />
 		
 	<!-- Favicons -->
 	<link rel="shortcut icon" href="favicon.ico" />
@@ -338,7 +338,7 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
 
 <!-- Scripts -->
-<script type="text/javascript" src="scripts/script-all.min.js%3Fv1"></script>
+<script type="text/javascript" src="scripts/script-all.min.js?v1"></script>
 
 
 <!-- Start Google Analytics -->


### PR DESCRIPTION
- Changed href for style.min.css%3Fv1.css to style.min.css?v1.css.
- Changed src for script-all.min.js%3Fv1 to script-all.min.js?v1.

This change is intended to match the actual filenames that include a '?' character, which was causing issues with URL encoding (%3F) when resolving paths on GitHub Pages, leading to broken styling and functionality.